### PR TITLE
Add header serialization

### DIFF
--- a/src/domain/entities/models.rs
+++ b/src/domain/entities/models.rs
@@ -409,11 +409,11 @@ pub struct EmailContent {
 pub struct Header {
     /// The name of the header.
     #[serde(rename = "name")]
-    name: Option<String>,
+    pub name: Option<String>,
 
     /// The value of the header.
     #[serde(rename = "value")]
-    value: Option<String>,
+    pub value: Option<String>,
 }
 
 /// Represents the recipients of an email.


### PR DESCRIPTION
As a follow-up to #5, I added serializers and deserializers for headers. To serialize them into the required `"<name>": "<value>"` shape I introduced `HeaderSet` as an intermediate struct. 

This now allows setting mail headers as expected with ACS.