### PR TITLE
Merge from main

### DIFF
--- a/src/domain/entities/models.rs
+++ b/src/domain/entities/models.rs
@@ -409,11 +409,11 @@ pub struct EmailContent {
 pub struct Header {
     /// The name of the header.
     #[serde(rename = "name")]
-    name: Option<String>,
+    pub name: Option<String>,
 
     /// The value of the header.
     #[serde(rename = "value")]
-    value: Option<String>,
+    pub value: Option<String>,
 }
 
 /// Represents the recipients of an email.


### PR DESCRIPTION
This pull request introduces a new `HeaderSet` struct to replace `Vec<Header>` in the `SentEmail` struct and its builder, and includes serialization and deserialization implementations for `HeaderSet`. Additionally, it updates the `Header` struct and adds tests for the new functionality.

Changes to data structures:

* [`src/domain/entities/models.rs`](diffhunk://#diff-8e32b431cb7df58bd3733cc21589adee2b26032ae503d1ddc40eb6d53e7dd38cL90-R90): Replaced `Option<Vec<Header>>` with `Option<HeaderSet>` in `SentEmail` and `SentEmailBuilder`, and updated the `headers` method in `SentEmailBuilder` accordingly. [[1]](diffhunk://#diff-8e32b431cb7df58bd3733cc21589adee2b26032ae503d1ddc40eb6d53e7dd38cL90-R90) [[2]](diffhunk://#diff-8e32b431cb7df58bd3733cc21589adee2b26032ae503d1ddc40eb6d53e7dd38cL122-R122) [[3]](diffhunk://#diff-8e32b431cb7df58bd3733cc21589adee2b26032ae503d1ddc40eb6d53e7dd38cL160-R160)
* [`src/domain/entities/models.rs`](diffhunk://#diff-8e32b431cb7df58bd3733cc21589adee2b26032ae503d1ddc40eb6d53e7dd38cR407-R420): Introduced `HeaderSet` struct to represent a set of headers.

Serialization and deserialization:

* [`src/domain/entities/models.rs`](diffhunk://#diff-8e32b431cb7df58bd3733cc21589adee2b26032ae503d1ddc40eb6d53e7dd38cR513-R549): Implemented `Serialize` and `Deserialize` traits for `HeaderSet`.

Testing:

* [`src/domain/entities/models.rs`](diffhunk://#diff-8e32b431cb7df58bd3733cc21589adee2b26032ae503d1ddc40eb6d53e7dd38cR612-R667): Added tests for `HeaderSet` serialization and deserialization, including tests for empty header sets.