### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [0.3.0] — unreleased
+## [0.4.0] — unreleased
+
+### Added
+
+- **Configurable poll interval** — `.poll_interval(Duration)` on `ACSClientBuilder` controls the delay between status polls in `send_email_and_wait*`, `send_email_stream*`, and the callback variants. Default: 5 s (same as the previous hardcoded value — no behaviour change for existing callers).
+- **`send_email_and_wait`** — `ACSClient::send_email_and_wait(email, timeout: Duration) -> Result<EmailSendStatusType, ACSError>` sends an email and blocks until a terminal status is observed or the deadline elapses. Returns `ACSError::Timeout` when the deadline expires; the email may still be delivered.
+- **`send_email_and_wait_cancellable`** — identical to `send_email_and_wait` but accepts a `CancellationToken`; returns `ACSError::Canceled` when the token is cancelled before a terminal status is observed. Cancellation only stops the local wait — the email remains queued in ACS.
+- **`send_email_idempotent`** — `ACSClient::send_email_idempotent(email, idempotency_key: &str)` sets `repeatability-request-id` and `repeatability-first-sent` headers on the initial request and all retries, making application-level retries safe against double-sends.
+- **`ACSError::Timeout`** — returned by `send_email_and_wait` and `send_email_and_wait_cancellable` when the deadline elapses before a terminal status.
+- **`ACSError::Canceled`** — returned by `send_email_and_wait_cancellable` when the `CancellationToken` is cancelled before a terminal status.
+- **`examples/mail_wait.rs`** — demonstrates `send_email_and_wait` and `send_email_and_wait_cancellable` with a simulated shutdown abort.
+
+### Security
+
+- **Access key no longer logged** — `acs_shared_key::parse_endpoint` previously emitted the raw Shared Key (HMAC secret) at `debug!` level. The log line has been removed.
+- **OAuth client secret no longer logged** — `examples/mail.rs` previously emitted the Service Principal `client_secret` at `debug!` level. The log line has been removed.
+
+### Documentation
+
+- **README** — new "Choosing a Send Method" section with a decision table and flowchart to help callers pick the right API; added code examples for `send_email_and_wait` and `send_email_and_wait_cancellable`; updated examples table.
+- **Rust doc comments** — all public `ACSClientBuilder` methods (`new`, `api_version`, `host`, `connection_string`, `service_principal`, `managed_identity`, `build`) upgraded from `//` inline comments to `///` doc comments, now visible on docs.rs. Private helper functions simplified from verbose `# Arguments` / `# Returns` blocks to concise summaries.
+- **CLAUDE.md** — full public API list, all error variants, complete integration test table, `poll_interval` builder option documented.
+
+### Tests
+
+136 → 157 (+21 unit + integration tests covering `poll_interval` builder propagation, clone preservation, all `send_email_and_wait*` and `send_email_idempotent` paths including timeout, cancellation, send failure, poll error, and idempotency header presence on retries).
+
+---
+
+## [0.3.0] — 2026-05-10
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [0.4.0] — unreleased
+## [0.4.0] — 2026-05-10
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 cargo build                                          # build
-cargo test                                           # run all 136 tests (unit + integration)
+cargo test                                           # run all 157 tests (unit + integration)
 cargo clippy -- -D warnings                          # lint (must pass clean for CI)
 cargo fmt --check                                    # format check (must pass clean for CI)
 cargo test <name>                                    # run a single test by name substring
@@ -20,6 +20,7 @@ cargo clippy                                         # lint
 cargo run --example mail                             # sync example (shared key auth)
 cargo run --example mail_async                       # async example (service principal auth)
 cargo run --example mail_attach                      # async example with attachments
+cargo run --example mail_wait                        # send_email_and_wait + send_email_and_wait_cancellable
 RUST_LOG=debug cargo run --example mail              # with debug logging
 ```
 
@@ -42,7 +43,7 @@ Inline in each module under `#[cfg(test)]`:
 
 | Module | What is tested |
 |---|---|
-| `acs_email.rs` | `ACSApiVersion` variants/default, `ACSClientBuilder` all construction paths + `host()` base-URL formation + error messages + `max_retries` + `timeout`, `parse_url`, `serialize_body`, all error helpers, `ACSError` Display/From/RateLimitExceeded, `wrap_http_client`, `is_terminal_status` all variants |
+| `acs_email.rs` | `ACSApiVersion` variants/default, `ACSClientBuilder` all construction paths + `host()` base-URL formation + error messages + `max_retries` + `timeout` + `poll_interval`, `parse_url`, `serialize_body`, all error helpers, `ACSError` Display/From/RateLimitExceeded/Timeout/Canceled, `wrap_http_client`, `is_terminal_status` all variants, clone preserves all fields |
 | `acs_shared_key.rs` | `compute_content_sha256` known SHA-256 vectors, `compute_signature` (valid, invalid, determinism, divergence), `parse_endpoint` all error cases, `get_request_header` all required headers + HMAC-SHA256 Authorization scheme |
 | `models.rs` | `SentEmailBuilder` (success, all missing-field errors, optional fields, `reply_to` with real addresses + JSON serialization), `EmailAttachmentBuilder` sync + async (`build_async`: valid file, missing file, MIME detection for PNG/octet-stream, filename extraction), `EmailSendStatusType` Display + `FromStr` all variants, `EmailSendStatus` Display + `to_type`, `HeaderSet` serde round-trip, `SentEmail` JSON serialization, tracing subscriber smoke test |
 
@@ -62,6 +63,20 @@ Live in `mod integration_tests` inside `acs_email.rs`. Use `wiremock` to start a
 | `send_email_stream_returns_error_when_send_fails` | Send 500 → stream itself returns `Err` before yielding |
 | `send_email_stream_yields_terminal_status_and_stops` | Send 202, status Succeeded → stream yields one item then terminates |
 | `send_email_stream_stops_on_status_error` | Send 202, status 404 → stream yields `Err` then terminates |
+| `send_email_and_wait_returns_terminal_status` | Send 202, status Succeeded → `Ok(Succeeded)` |
+| `send_email_and_wait_times_out` | Send 202, status always Running, poll_interval > timeout → `ACSError::Timeout` |
+| `send_email_and_wait_returns_failed_status` | Send 202, status Failed → `Ok(Failed)` |
+| `send_email_and_wait_send_fails_returns_send_error` | Send 500 → `ACSError::Api` (not Timeout) |
+| `send_email_and_wait_poll_error_propagates` | Send 202, status 404 → `ACSError::Api` (not Timeout) |
+| `send_email_and_wait_running_then_succeeded` | Running then Succeeded sequence → `Ok(Succeeded)` |
+| `send_email_and_wait_cancellable_returns_terminal_status` | Token never fired → succeeds normally |
+| `send_email_and_wait_cancellable_returns_canceled_when_token_fires` | Token cancelled mid-wait → `ACSError::Canceled` |
+| `send_email_and_wait_cancellable_already_cancelled_returns_canceled` | Pre-cancelled token → `ACSError::Canceled` immediately |
+| `send_email_and_wait_cancellable_times_out_before_cancel` | Deadline elapses before token → `ACSError::Timeout` |
+| `send_email_and_wait_cancellable_send_fails_returns_send_error` | Send 500 → `ACSError::Api` |
+| `send_email_idempotent_sends_repeatability_headers` | `repeatability-request-id` + `repeatability-first-sent` present in request |
+| `send_email_idempotent_returns_operation_id` | Returns ID from 202 body |
+| `send_email_idempotent_retries_on_429_preserves_key` | 429 then 202 — idempotency header present on retry |
 
 **How it works:** `ACSClientBuilder` has a `#[cfg(test)] pub(crate) fn base_url_override(url: &str)` method that replaces the computed `https://<host>` with the wiremock server URI. Auth headers are computed with a dummy shared key; the mock server ignores them.
 
@@ -105,18 +120,26 @@ src/
 
 ### Key types
 
-- **`ACSClient`** (`acs_email.rs`) — built via `ACSClientBuilder`. Holds auth method, base URL, shared `reqwest::Client`, and API version. Public API:
-  - `send_email(email: &SentEmail) -> Result<String, ACSError>`
-  - `send_email_with_callback(email, cb) -> Result<(String, Receiver<()>), ACSError>` — polls via tokio task, fires callback on each status update
-  - `get_email_status(operation_id: &str) -> Result<EmailSendStatusType, ACSError>`
+- **`ACSClient`** (`acs_email.rs`) — built via `ACSClientBuilder`. Holds auth method, base URL, shared `reqwest::Client`, API version, and poll interval. Public API:
+  - `send_email(email) -> Result<String, ACSError>` — queue and return operation ID
+  - `send_email_idempotent(email, key) -> Result<String, ACSError>` — queue with `repeatability-request-id` / `repeatability-first-sent` headers
+  - `send_email_and_wait(email, timeout) -> Result<EmailSendStatusType, ACSError>` — send + poll until terminal or deadline
+  - `send_email_and_wait_cancellable(email, timeout, token) -> Result<EmailSendStatusType, ACSError>` — same, stoppable via `CancellationToken`
+  - `send_emails_batch(emails) -> Vec<Result<String, ACSError>>` — concurrent multi-send
+  - `send_email_stream(email) -> Result<(String, impl Stream<…>), ACSError>` — per-status stream
+  - `send_email_stream_cancellable(email, token) -> Result<(String, impl Stream<…>), ACSError>`
+  - `send_email_with_callback(email, cb) -> Result<(String, Receiver<()>), ACSError>`
+  - `send_email_with_callback_cancellable(email, token, cb) -> Result<(String, Receiver<()>), ACSError>`
+  - `get_email_status(operation_id) -> Result<EmailSendStatusType, ACSError>`
 
-- **`ACSError`** (`models.rs`) — typed error enum via `thiserror`. Variants: `Network`, `InvalidUrl`, `Serialization`, `Deserialization`, `Auth`, `Header`, `Api { code, message }`, `MissingField`, `RateLimitExceeded { retries }`.
+- **`ACSError`** (`models.rs`) — typed error enum via `thiserror`. Variants: `Network`, `InvalidUrl`, `Serialization`, `Deserialization`, `Auth`, `Header`, `Api { code, message }`, `MissingField`, `RateLimitExceeded { retries }`, `Timeout`, `Canceled`.
 
 - **`ACSApiVersion`** — `V20230331` (default) / `V20250901`. Set via `.api_version()` on the builder.
 
 - **`ACSClientBuilder`** — fluent builder implementing `Default`. Key options:
   - `.timeout(Duration)` — per-request HTTP timeout (default: none)
   - `.max_retries(u32)` — retries on 429/503 with exponential backoff (default: 3)
+  - `.poll_interval(Duration)` — delay between status polls in `send_email_and_wait*`, `send_email_stream*`, and callback variants (default: 5 s)
   - `.api_version(ACSApiVersion)` — API version (default: `V20230331`)
 
 - **`SentEmail`** / **`SentEmailBuilder`** — top-level email object. Builder implements `Default`. Composes `EmailContent`, `Recipients`, optional `Vec<EmailAttachment>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure-ecs-rs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Azure ECS (Email Communication Service) Rust SDK"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,48 @@ Rust SDK for the [Azure Email Communication Service](https://learn.microsoft.com
 | `ACSApiVersion::V20230331` | `2023-03-31` | Default — backward compatible |
 | `ACSApiVersion::V20250901` | `2025-09-01` | Latest stable — opt-in |
 
+## Choosing a Send Method
+
+The SDK exposes several send methods. Use this table to pick the right one for your situation.
+
+| Method | Use when |
+|---|---|
+| [`send_email`](#send-email) | You queue the email and track delivery yourself later (fire-and-queue). |
+| [`send_email_idempotent`](#idempotent-send) | Same as above, but your code may retry on network failure — the key prevents double-sends. |
+| [`send_emails_batch`](#batch-send) | You need to dispatch many emails concurrently in one call. |
+| [`send_email_and_wait`](#wait-for-terminal-status) | You want a single `await` that returns the final delivery status. Simplest option when you can afford to block the task. |
+| [`send_email_and_wait_cancellable`](#wait-with-cancellation) | Same as above, but inside a request handler or task that may be shut down early (e.g. axum, gRPC, CLI with Ctrl-C). |
+| [`send_email_stream`](#stream-based-status-polling) | You need to react to *each* status transition — progress UI, per-step logging, custom retry logic. |
+| [`send_email_stream_cancellable`](#stream-with-cancellation) | Same as above, but the consumer may abandon the stream before delivery completes. |
+| [`send_email_with_callback`](#callback-original-api-backward-compatible) | You want a background task to fire a closure on each status update (metrics, audit log). |
+| [`send_email_with_callback_cancellable`](#callback-with-cancellation) | Same as above, but the background task must stop cleanly on a shutdown signal. |
+
+**Decision flowchart**
+
+```
+Do you need delivery confirmation?
+├── No  → send_email (or send_email_idempotent if retries are needed)
+│
+└── Yes
+    │
+    ├── Many emails at once?
+    │   └── Yes → send_emails_batch
+    │
+    ├── Need to react to each status step?
+    │   ├── Yes → send_email_stream / send_email_stream_cancellable
+    │   └── No
+    │
+    ├── Need a side-effect callback per update (e.g. metrics)?
+    │   ├── Yes → send_email_with_callback / send_email_with_callback_cancellable
+    │   └── No
+    │
+    └── Just want a single await for the final status?
+        ├── No cancellation needed → send_email_and_wait
+        └── Must be stoppable (request context / shutdown) → send_email_and_wait_cancellable
+```
+
+> **Cancellation note:** cancellation only stops the *local wait/poll loop* — the email remains queued in ACS and may still be delivered. `ACSError::Canceled` distinguishes early abort from `ACSError::Timeout` (deadline elapsed) and from a real API error.
+
 ## Quick Start
 
 ### Build the client
@@ -196,6 +238,58 @@ let (operation_id, done_rx) = client
 let _ = done_rx.await;
 ```
 
+### Wait for terminal status
+
+Send and block until `Succeeded`, `Failed`, `Canceled`, or `Unknown` — no stream
+or callback needed. `ACSError::Timeout` is returned if no terminal state is
+observed within the deadline; the email may still be in transit.
+
+```rust
+use azure_ecs_rs::domain::entities::models::{ACSError, EmailSendStatusType};
+use std::time::Duration;
+
+match client.send_email_and_wait(&email, Duration::from_secs(60)).await {
+    Ok(EmailSendStatusType::Succeeded) => println!("delivered"),
+    Ok(EmailSendStatusType::Failed)    => eprintln!("delivery failed"),
+    Ok(status)                         => println!("terminal: {status}"),
+    Err(ACSError::Timeout)             => eprintln!("timed out — email may still be in transit"),
+    Err(e)                             => eprintln!("error: {e}"),
+}
+```
+
+Use `.poll_interval(Duration)` on the builder to control how often status is
+polled (default: 5 s).
+
+### Wait with cancellation
+
+`send_email_and_wait_cancellable` adds a [`CancellationToken`] so an external
+signal — a shutdown handler, an HTTP request context, a test harness — can abort
+the wait without leaking the poll loop. The email stays queued in ACS and may
+still be delivered.
+
+```rust
+use tokio_util::sync::CancellationToken;
+use azure_ecs_rs::domain::entities::models::{ACSError, EmailSendStatusType};
+use std::time::Duration;
+
+let token = CancellationToken::new();
+
+// Cancel from another task at any time: token.cancel()
+
+match client
+    .send_email_and_wait_cancellable(&email, Duration::from_secs(60), token)
+    .await
+{
+    Ok(EmailSendStatusType::Succeeded) => println!("delivered"),
+    Err(ACSError::Canceled)            => eprintln!("wait cancelled — email may still deliver"),
+    Err(ACSError::Timeout)             => eprintln!("timed out"),
+    Err(e)                             => eprintln!("error: {e}"),
+    Ok(status)                         => println!("terminal: {status}"),
+}
+```
+
+[`CancellationToken`]: https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html
+
 ### Poll status manually
 
 ```rust
@@ -294,13 +388,14 @@ via `tracing-log`, so no changes are needed if you already use `pretty_env_logge
 | `cargo run --example mail_error_handling` | Typed `ACSError` matching |
 | `cargo run --example mail_retry_timeout` | Retry and timeout configuration |
 | `cargo run --example mail_stream` | Stream-based status polling |
+| `cargo run --example mail_wait` | `send_email_and_wait` + `send_email_and_wait_cancellable` |
 
 Prefix any example with `RUST_LOG=debug` to enable tracing output.
 
 ## Testing
 
 ```bash
-cargo test                          # 136 unit + wiremock tests — no credentials needed
+cargo test                          # 157 unit + wiremock tests — no credentials needed
 cargo test --test azure_e2e -- --include-ignored   # real Azure E2E (credentials required)
 ```
 

--- a/examples/mail.rs
+++ b/examples/mail.rs
@@ -115,7 +115,6 @@ async fn send_email_with_api(
             debug!("host_name: {}", host_name);
             debug!("tenant_id: {}", tenant_id);
             debug!("client_id: {}", client_id);
-            debug!("client_secret: {}", client_secret);
             ACSClientBuilder::new()
                 .host(host_name.as_str())
                 .service_principal(

--- a/examples/mail.rs
+++ b/examples/mail.rs
@@ -151,6 +151,9 @@ async fn send_email_with_api(
 
     debug!("Email request: {:#?}", email_request);
 
+    // To use API version 2025-09-01 instead of the default (2023-03-31):
+    //   use azure_ecs_rs::adapters::gateways::acs_email::ACSApiVersion;
+    //   acs_client_builder.api_version(ACSApiVersion::V20250901).build()
     let acs_client = acs_client_builder
         .build()
         .expect("Failed to build ACSClient");

--- a/examples/mail_wait.rs
+++ b/examples/mail_wait.rs
@@ -1,0 +1,137 @@
+/// Example: send and wait for terminal delivery status
+///
+/// Demonstrates two variants:
+///
+/// 1. `send_email_and_wait` — blocks until Succeeded/Failed or a 60 s deadline.
+/// 2. `send_email_and_wait_cancellable` — same, but a `CancellationToken` lets
+///    another task (e.g. a web request handler) abort the wait early without
+///    leaking the background poll loop.
+///
+/// Run:
+///   RUST_LOG=info cargo run --example mail_wait
+use std::env;
+use std::time::Duration;
+
+use azure_ecs_rs::adapters::gateways::acs_email::ACSClientBuilder;
+use azure_ecs_rs::domain::entities::models::{
+    ACSError, EmailAddress, EmailContent, EmailSendStatusType, Recipients, SentEmailBuilder,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+use tracing_subscriber::EnvFilter;
+
+fn get_env_var(name: &str) -> String {
+    env::var(name).unwrap_or_else(|_| panic!("env var {} not set", name))
+}
+
+fn build_email(
+    sender: String,
+    recipient: String,
+    display_name: String,
+    subject: &str,
+) -> azure_ecs_rs::domain::entities::models::SentEmail {
+    SentEmailBuilder::new()
+        .sender(sender)
+        .content(EmailContent {
+            subject: Some(subject.to_string()),
+            plain_text: Some(format!("Sent via {}.", subject)),
+            html: None,
+        })
+        .recipients(Recipients {
+            to: Some(vec![EmailAddress {
+                email: Some(recipient),
+                display_name: Some(display_name),
+            }]),
+            cc: None,
+            b_cc: None,
+        })
+        .build()
+        .expect("Failed to build SentEmail")
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    dotenv::dotenv().ok();
+
+    let connection_str = get_env_var("CONNECTION_STR");
+    let sender = get_env_var("SENDER");
+    let recipient = get_env_var("REPLY_EMAIL");
+    let display_name = get_env_var("REPLY_EMAIL_DISPLAY");
+
+    let client = ACSClientBuilder::new()
+        .connection_string(&connection_str)
+        .timeout(Duration::from_secs(30))
+        .max_retries(3)
+        .poll_interval(Duration::from_secs(5))
+        .build()
+        .expect("Failed to build ACSClient");
+
+    // ── 1. send_email_and_wait ────────────────────────────────────────────────
+    //
+    // Single call that returns the final delivery status.
+    // ACSError::Timeout is returned if ACS hasn't reached a terminal state
+    // within the deadline — the email may still be in transit.
+    info!("Sending via send_email_and_wait (60 s deadline)…");
+
+    let email = build_email(
+        sender.clone(),
+        recipient.clone(),
+        display_name.clone(),
+        "send_email_and_wait example",
+    );
+
+    match client
+        .send_email_and_wait(&email, Duration::from_secs(60))
+        .await
+    {
+        Ok(EmailSendStatusType::Succeeded) => info!("Delivered"),
+        Ok(EmailSendStatusType::Failed) => error!("Delivery failed"),
+        Ok(status) => warn!(%status, "Unexpected terminal status"),
+        Err(ACSError::Timeout) => warn!("Timed out — email may still be in transit"),
+        Err(e) => error!(err = %e, "Send failed"),
+    }
+
+    // ── 2. send_email_and_wait_cancellable ────────────────────────────────────
+    //
+    // A CancellationToken lets an external signal (e.g. a shutdown handler or
+    // an HTTP request context) abort the wait cleanly. The email remains queued
+    // in ACS; only the local wait is abandoned.
+    info!("Sending via send_email_and_wait_cancellable (60 s deadline)…");
+
+    let email2 = build_email(
+        sender,
+        recipient,
+        display_name,
+        "send_email_and_wait_cancellable example",
+    );
+
+    let token = CancellationToken::new();
+
+    // Simulate an external abort after 10 s (e.g. process shutdown signal).
+    let abort_token = token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        info!("Simulating external cancellation…");
+        abort_token.cancel();
+    });
+
+    match client
+        .send_email_and_wait_cancellable(&email2, Duration::from_secs(60), token)
+        .await
+    {
+        Ok(EmailSendStatusType::Succeeded) => info!("Delivered"),
+        Ok(EmailSendStatusType::Failed) => error!("Delivery failed"),
+        Ok(status) => warn!(%status, "Unexpected terminal status"),
+        Err(ACSError::Canceled) => {
+            warn!("Wait cancelled — email is still queued in ACS and may be delivered later")
+        }
+        Err(ACSError::Timeout) => warn!("Timed out — email may still be in transit"),
+        Err(e) => error!(err = %e, "Send failed"),
+    }
+
+    Ok(())
+}

--- a/src/adapters/gateways/acs_email.rs
+++ b/src/adapters/gateways/acs_email.rs
@@ -7,9 +7,9 @@
 //! - [`ACSClient`] — clone-cheap handle (all fields behind `Arc` or `Clone`).
 //!   Owns the HTTP client and dispatches the public operations:
 //!   [`send_email`], [`send_email_idempotent`], [`send_email_and_wait`],
-//!   [`send_emails_batch`], [`send_email_with_callback`],
-//!   [`send_email_with_callback_cancellable`], [`send_email_stream`],
-//!   [`send_email_stream_cancellable`], and [`get_email_status`].
+//!   [`send_email_and_wait_cancellable`], [`send_emails_batch`],
+//!   [`send_email_with_callback`], [`send_email_with_callback_cancellable`],
+//!   [`send_email_stream`], [`send_email_stream_cancellable`], and [`get_email_status`].
 //!
 //! # Pool-friendly usage
 //!
@@ -59,6 +59,7 @@
 //! [`send_email`]: ACSClient::send_email
 //! [`send_email_idempotent`]: ACSClient::send_email_idempotent
 //! [`send_email_and_wait`]: ACSClient::send_email_and_wait
+//! [`send_email_and_wait_cancellable`]: ACSClient::send_email_and_wait_cancellable
 //! [`send_emails_batch`]: ACSClient::send_emails_batch
 //! [`send_email_with_callback`]: ACSClient::send_email_with_callback
 //! [`send_email_with_callback_cancellable`]: ACSClient::send_email_with_callback_cancellable
@@ -618,6 +619,51 @@ impl ACSClient {
                 let status = self.get_email_status(&operation_id).await?;
                 if is_terminal_status(&status) {
                     return Ok(status);
+                }
+            }
+        })
+        .await
+        .map_err(|_| ACSError::Timeout)?
+    }
+
+    /// Send an email and block until terminal status, timeout, or cancellation.
+    ///
+    /// Identical to [`send_email_and_wait`] but adds cooperative cancellation via
+    /// a [`CancellationToken`].  When the token is cancelled before a terminal
+    /// status is observed the method returns [`ACSError::Canceled`] immediately,
+    /// without issuing another status poll.  If the deadline elapses first,
+    /// [`ACSError::Timeout`] is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// - [`ACSError::Canceled`] — `token` was cancelled before terminal status.
+    /// - [`ACSError::Timeout`] — `timeout` elapsed before terminal status.
+    /// - All errors from [`send_email`] and [`get_email_status`].
+    ///
+    /// [`send_email_and_wait`]: ACSClient::send_email_and_wait
+    /// [`send_email`]: ACSClient::send_email
+    /// [`get_email_status`]: ACSClient::get_email_status
+    /// [`CancellationToken`]: tokio_util::sync::CancellationToken
+    #[instrument(skip(self, email, token), fields(host = %self.host, api_version = %self.api_version.as_str()))]
+    pub async fn send_email_and_wait_cancellable(
+        &self,
+        email: &SentEmail,
+        timeout: Duration,
+        token: CancellationToken,
+    ) -> EmailResult<EmailSendStatusType> {
+        let operation_id = self.send_email(email).await?;
+        tokio::time::timeout(timeout, async {
+            loop {
+                tokio::select! {
+                    _ = token.cancelled() => {
+                        return Err(ACSError::Canceled);
+                    }
+                    _ = sleep(self.poll_interval) => {
+                        let status = self.get_email_status(&operation_id).await?;
+                        if is_terminal_status(&status) {
+                            return Ok(status);
+                        }
+                    }
                 }
             }
         })
@@ -1460,6 +1506,13 @@ mod tests {
         let e = ACSError::Timeout;
         let s = e.to_string();
         assert!(s.contains("timed out"));
+    }
+
+    #[test]
+    fn acs_error_display_canceled() {
+        let e = ACSError::Canceled;
+        let s = e.to_string();
+        assert!(s.contains("cancel"));
     }
 
     #[test]
@@ -3036,5 +3089,162 @@ mod integration_tests {
             .send_email_and_wait(&email, Duration::from_secs(5))
             .await;
         assert!(matches!(result, Ok(EmailSendStatusType::Succeeded)));
+    }
+
+    // ── send_email_and_wait_cancellable ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_email_and_wait_cancellable_returns_terminal_status() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(202).set_body_json(json!({ "id": "op-cancellable-ok" })),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "status": "Succeeded" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .poll_interval(Duration::from_millis(10))
+            .build()
+            .unwrap();
+
+        let token = CancellationToken::new();
+        let result = client
+            .send_email_and_wait_cancellable(&email, Duration::from_secs(5), token)
+            .await;
+        assert!(matches!(result, Ok(EmailSendStatusType::Succeeded)));
+    }
+
+    #[tokio::test]
+    async fn send_email_and_wait_cancellable_returns_canceled_when_token_fires() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(202).set_body_json(json!({ "id": "op-cancellable-tok" })),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "Running" })))
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .poll_interval(Duration::from_secs(60)) // longer than cancel fires
+            .build()
+            .unwrap();
+
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+        // Cancel after a short delay
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            token_clone.cancel();
+        });
+
+        let result = client
+            .send_email_and_wait_cancellable(&email, Duration::from_secs(5), token)
+            .await;
+        assert!(matches!(result, Err(ACSError::Canceled)));
+    }
+
+    #[tokio::test]
+    async fn send_email_and_wait_cancellable_already_cancelled_returns_canceled() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(202).set_body_json(json!({ "id": "op-precancelled" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .poll_interval(Duration::from_millis(10))
+            .build()
+            .unwrap();
+
+        let token = CancellationToken::new();
+        token.cancel(); // pre-cancelled before the call
+
+        let result = client
+            .send_email_and_wait_cancellable(&email, Duration::from_secs(5), token)
+            .await;
+        assert!(matches!(result, Err(ACSError::Canceled)));
+    }
+
+    #[tokio::test]
+    async fn send_email_and_wait_cancellable_times_out_before_cancel() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(202).set_body_json(json!({ "id": "op-timeout-wins" })),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "Running" })))
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .poll_interval(Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let token = CancellationToken::new(); // never cancelled
+        let result = client
+            .send_email_and_wait_cancellable(&email, Duration::from_millis(50), token)
+            .await;
+        assert!(matches!(result, Err(ACSError::Timeout)));
+    }
+
+    #[tokio::test]
+    async fn send_email_and_wait_cancellable_send_fails_returns_send_error() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(500).set_body_json(
+                    json!({ "error": { "code": "InternalError", "message": "boom" } }),
+                ),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .max_retries(0)
+            .build()
+            .unwrap();
+
+        let token = CancellationToken::new();
+        let result = client
+            .send_email_and_wait_cancellable(&email, Duration::from_secs(5), token)
+            .await;
+        assert!(matches!(result, Err(ACSError::Api { .. })));
     }
 }

--- a/src/adapters/gateways/acs_email.rs
+++ b/src/adapters/gateways/acs_email.rs
@@ -220,7 +220,12 @@ impl Default for ACSClientBuilder {
 }
 
 impl ACSClientBuilder {
-    // Create a new builder instance
+    /// Create a new builder with default settings.
+    ///
+    /// Equivalent to `ACSClientBuilder::default()`.  Configure the builder with
+    /// the chained setters below, then call [`build`] to obtain an [`ACSClient`].
+    ///
+    /// [`build`]: ACSClientBuilder::build
     pub fn new() -> Self {
         ACSClientBuilder {
             host: None,
@@ -242,6 +247,11 @@ impl ACSClientBuilder {
         self
     }
 
+    /// Select the ACS REST API version used for all requests on the built client.
+    ///
+    /// The default is [`ACSApiVersion::V20230331`] for backward compatibility.
+    /// Use [`ACSApiVersion::V20250901`] when you need explicit version pinning.
+    /// Both versions expose identical data-plane operations.
     pub fn api_version(mut self, version: ACSApiVersion) -> Self {
         self.api_version = version;
         self
@@ -276,19 +286,48 @@ impl ACSClientBuilder {
         self
     }
 
-    // Set the host for the client
+    /// Set the ACS resource hostname or full URL.
+    ///
+    /// Required when authenticating with [`service_principal`] or
+    /// [`managed_identity`].  Accepts either a bare hostname
+    /// (`"myresource.communication.azure.com"`) or a full `https://` URL —
+    /// the scheme prefix is stripped before use.
+    ///
+    /// Not needed when using [`connection_string`], which carries the host
+    /// inside the connection string value.
+    ///
+    /// [`service_principal`]: ACSClientBuilder::service_principal
+    /// [`managed_identity`]: ACSClientBuilder::managed_identity
+    /// [`connection_string`]: ACSClientBuilder::connection_string
     pub fn host(mut self, host: &str) -> Self {
         self.host = Some(host.to_string());
         self
     }
 
-    // Set the authentication method for the client using a shared key
+    /// Configure Shared Key authentication from an ACS connection string.
+    ///
+    /// The connection string has the form
+    /// `endpoint=https://<resource>.communication.azure.com;accesskey=<base64-key>`
+    /// and can be copied directly from the Azure Portal → Keys blade.
+    ///
+    /// Setting this option makes [`host`] unnecessary — the endpoint is
+    /// extracted from the connection string.
+    ///
+    /// [`host`]: ACSClientBuilder::host
     pub fn connection_string(mut self, connection_string: &str) -> Self {
         self.connection_string = Some(connection_string.to_string());
         self
     }
 
-    // Set the authentication method for the client using a service principal
+    /// Configure Service Principal (client-credentials) authentication.
+    ///
+    /// An OAuth2 client-credentials token is fetched from Azure AD on every
+    /// request using the supplied `tenant_id`, `client_id`, and
+    /// `client_secret`.  Tokens are not cached between requests.
+    ///
+    /// Requires [`host`] to also be set.
+    ///
+    /// [`host`]: ACSClientBuilder::host
     pub fn service_principal(
         mut self,
         tenant_id: &str,
@@ -303,13 +342,36 @@ impl ACSClientBuilder {
         self
     }
 
-    // Set the authentication method for the client using managed identity
+    /// Configure Managed Identity authentication.
+    ///
+    /// An ambient token is obtained from the Azure Instance Metadata Service
+    /// (IMDS) on every request.  This works inside Azure VMs, App Services,
+    /// Container Apps, AKS pods with a workload identity, and any other
+    /// environment where a managed identity is assigned.  No credentials need
+    /// to be stored in code or environment variables.
+    ///
+    /// Requires [`host`] to also be set.
+    ///
+    /// [`host`]: ACSClientBuilder::host
     pub fn managed_identity(mut self) -> Self {
         self.auth_method = Some(ACSAuthMethod::ManagedIdentity);
         self
     }
 
-    // Build and return the ACSClient
+    /// Validate the configuration and build an [`ACSClient`].
+    ///
+    /// Constructs the shared [`reqwest::Client`] (including TLS) once.  All
+    /// subsequent calls on the returned [`ACSClient`] — and all of its clones
+    /// — reuse this client, amortising connection setup across requests.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(String)` when:
+    /// - The connection string is present but malformed.
+    /// - Neither a connection string nor a host was provided.
+    /// - A host was provided but no authentication method was set.
+    /// - The underlying HTTP client could not be built (rare; usually a TLS
+    ///   configuration issue).
     pub fn build(self) -> Result<ACSClient, String> {
         let mut client_builder = Client::builder();
         if let Some(timeout) = self.timeout {
@@ -905,15 +967,11 @@ fn wrap_http_client(client: &Client) -> Arc<dyn HttpClient> {
     Arc::new(client.clone()) as Arc<dyn HttpClient>
 }
 
-/// Get an access token based on the provided authentication method.
+/// Acquire a bearer token for the given authentication method.
 ///
-/// # Arguments
-///
-/// * `auth_method` - A reference to the `ACSAuthMethod` enum specifying the authentication method.
-///
-/// # Returns
-///
-/// * `Result<String, String>` - The result of the token acquisition, containing the token if successful.
+/// Returns an empty string for `SharedKey` (auth is handled via HMAC headers
+/// instead).  For `ServicePrincipal` and `ManagedIdentity` the token is
+/// fetched from Azure AD / IMDS on every call — responses are not cached.
 async fn get_access_token(
     http_client: &Client,
     auth_method: &ACSAuthMethod,
@@ -955,19 +1013,12 @@ async fn get_access_token(
     Ok(String::new())
 }
 
-/// Create headers for the request based on the provided authentication method.
+/// Build the required HTTP headers for a single request.
 ///
-/// # Arguments
-///
-/// * `url_endpoint` - A reference to the `Url` struct representing the endpoint URL.
-/// * `method` - A reference to the HTTP method string.
-/// * `request_id` - A reference to the request ID string.
-/// * `json_body` - A reference to the JSON body string.
-/// * `auth_method` - A reference to the `ACSAuthMethod` enum specifying the authentication method.
-///
-/// # Returns
-///
-/// * `EmailResult<reqwest::header::HeaderMap>` - The result of the header creation, containing the headers if successful.
+/// For `SharedKey` auth the full HMAC-SHA256 header set is computed via
+/// `acs_shared_key`.  For `ServicePrincipal` / `ManagedIdentity` a bearer
+/// token is fetched and `Authorization`, `Content-Type`, and
+/// `x-ms-client-request-id` headers are set.
 async fn create_headers(
     http_client: &Client,
     url_endpoint: &Url,
@@ -1005,16 +1056,6 @@ async fn create_headers(
     Ok(headers)
 }
 
-/// Convert an error into an `ErrorResponse`.
-///
-/// # Arguments
-///
-/// * `message` - A reference to the error message string.
-/// * `error` - An object that implements the `ToString` trait.
-///
-/// # Returns
-///
-/// * `ErrorResponse` - The error response containing the error details.
 fn network_err(detail: impl ToString) -> ACSError {
     ACSError::Network(detail.to_string())
 }
@@ -1039,17 +1080,7 @@ fn auth_err(detail: impl ToString) -> ACSError {
     ACSError::Auth(detail.to_string())
 }
 
-/// Get the status of a sent email using the ACS client.
-///
-/// # Arguments
-///
-/// * `base_url` - Base URL including scheme, e.g. `https://resource.communication.azure.com`.
-/// * `acs_auth_method` - A reference to the `ACSAuthMethod` enum specifying the authentication method.
-/// * `request_id` - A reference to the request ID string.
-///
-/// # Returns
-///
-/// * `EmailResult<EmailSendStatusType>` - The result of the email status query, containing the status if successful.
+/// Fetch the current delivery status for a single ACS operation ID.
 #[instrument(skip(http_client, acs_auth_method), fields(base_url = %base_url))]
 async fn acs_get_email_status(
     http_client: &Client,
@@ -1106,18 +1137,12 @@ fn build_repeatability_headers(
     Some(headers)
 }
 
-/// Send an email using the ACS client.
+/// POST a single email to the ACS `emails:send` endpoint and return the operation ID.
 ///
-/// # Arguments
-///
-/// * `base_url` - Base URL including scheme, e.g. `https://resource.communication.azure.com`.
-/// * `acs_auth_method` - A reference to the `ACSAuthMethod` enum specifying the authentication method.
-/// * `request_id` - A reference to the request ID string.
-/// * `email` - A reference to the `SentEmail` struct containing the email details.
-///
-/// # Returns
-///
-/// * `EmailResult<String>` - The result of the email send operation, containing the message ID if successful.
+/// Handles the initial request and delegates retry / backoff logic to
+/// [`handle_response_and_retry_if_needed`].  When `idempotency_key` is `Some`,
+/// the `repeatability-request-id` and `repeatability-first-sent` headers are
+/// included on the initial request and all retries.
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip(http_client, acs_auth_method, email, idempotency_key), fields(base_url = %base_url, max_retries = %max_retries))]
 async fn acs_send_email(
@@ -1161,21 +1186,13 @@ async fn acs_send_email(
     )
     .await
 }
-/// Handle the response from the email send operation and retry if needed.
+/// Inspect an HTTP response and retry on `429` / `503` up to `max_retries` times.
 ///
-/// # Arguments
-///
-/// * `response` - The `reqwest::Response` object.
-/// * `method` - The HTTP method used for the request.
-/// * `url` - The URL to send the request to.
-/// * `request_id` - The request ID string.
-/// * `body` - An optional reference to the request body.
-/// * `acs_auth_method` - A reference to the `ACSAuthMethod` enum specifying the authentication method.
-/// * `max_retries` - The maximum number of retries.
-///
-/// # Returns
-///
-/// * `EmailResult<String>` - The result of the response handling, containing the message ID if successful.
+/// On `202 Accepted` the operation ID is extracted from the response body.
+/// On `429 Too Many Requests` or `503 Service Unavailable` the request is
+/// retried after the delay specified in the `Retry-After` header, or after
+/// exponential backoff (`2^n` seconds) when that header is absent.
+/// Any other status code is treated as a permanent failure.
 #[allow(clippy::too_many_arguments)]
 async fn handle_response_and_retry_if_needed<T>(
     http_client: &Client,
@@ -1252,15 +1269,7 @@ where
     }
 }
 
-/// Parse the response from the email send operation.
-///
-/// # Arguments
-///
-/// * `response` - The `reqwest::Response` object.
-///
-/// # Returns
-///
-/// * `EmailResult<T>` - The result of the response parsing, containing the parsed response if successful.
+/// Deserialize a successful response body into `T`.
 async fn parse_response<T>(response: reqwest::Response) -> EmailResult<T>
 where
     T: serde::de::DeserializeOwned,
@@ -1268,15 +1277,7 @@ where
     response.json::<T>().await.map_err(parse_err)
 }
 
-/// Parse the error response from the email send operation.
-///
-/// # Arguments
-///
-/// * `response` - The `reqwest::Response` object.
-///
-/// # Returns
-///
-/// * `EmailResult<String>` - The result of the error response parsing, containing the error response if successful.
+/// Deserialize an error response body and return it as `Err(ACSError::Api)`.
 async fn parse_error_response(response: reqwest::Response) -> EmailResult<String> {
     let error_response = parse_response::<ErrorResponse>(response).await?;
     Err(ACSError::from(error_response))

--- a/src/adapters/gateways/acs_email.rs
+++ b/src/adapters/gateways/acs_email.rs
@@ -6,7 +6,8 @@
 //!   the shared [`reqwest::Client`] once so all requests reuse the same connection pool.
 //! - [`ACSClient`] — clone-cheap handle (all fields behind `Arc` or `Clone`).
 //!   Owns the HTTP client and dispatches the public operations:
-//!   [`send_email`], [`send_emails_batch`], [`send_email_with_callback`],
+//!   [`send_email`], [`send_email_idempotent`], [`send_email_and_wait`],
+//!   [`send_emails_batch`], [`send_email_with_callback`],
 //!   [`send_email_with_callback_cancellable`], [`send_email_stream`],
 //!   [`send_email_stream_cancellable`], and [`get_email_status`].
 //!
@@ -56,6 +57,8 @@
 //! each request; responses are not cached.
 //!
 //! [`send_email`]: ACSClient::send_email
+//! [`send_email_idempotent`]: ACSClient::send_email_idempotent
+//! [`send_email_and_wait`]: ACSClient::send_email_and_wait
 //! [`send_emails_batch`]: ACSClient::send_emails_batch
 //! [`send_email_with_callback`]: ACSClient::send_email_with_callback
 //! [`send_email_with_callback_cancellable`]: ACSClient::send_email_with_callback_cancellable
@@ -137,6 +140,9 @@ enum ACSAuthMethod {
 /// Default number of retries for `429 Too Many Requests` and `503 Service Unavailable` responses.
 const DEFAULT_MAX_RETRIES: u32 = 3;
 
+/// Default interval between status-poll requests.
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
 /// Async HTTP client for the ACS Email data-plane API.
 ///
 /// Construct via [`ACSClientBuilder`].  The client is cheap to clone — the
@@ -178,6 +184,7 @@ pub struct ACSClient {
     api_version: ACSApiVersion,
     http_client: Client,
     max_retries: u32,
+    poll_interval: Duration,
 }
 
 /// Fluent builder for [`ACSClient`].
@@ -201,6 +208,7 @@ pub struct ACSClientBuilder {
     api_version: ACSApiVersion,
     max_retries: u32,
     timeout: Option<Duration>,
+    poll_interval: Duration,
     base_url_override: Option<String>,
 }
 
@@ -220,6 +228,7 @@ impl ACSClientBuilder {
             api_version: ACSApiVersion::default(),
             max_retries: DEFAULT_MAX_RETRIES,
             timeout: None,
+            poll_interval: DEFAULT_POLL_INTERVAL,
             base_url_override: None,
         }
     }
@@ -253,6 +262,16 @@ impl ACSClientBuilder {
     /// [`ACSError::Network`]. Default: no timeout.
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
+        self
+    }
+
+    /// Interval between status-poll requests used by [`send_email_stream`],
+    /// [`send_email_and_wait`], and the callback variants. Default: 5 s.
+    ///
+    /// [`send_email_stream`]: ACSClient::send_email_stream
+    /// [`send_email_and_wait`]: ACSClient::send_email_and_wait
+    pub fn poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
         self
     }
 
@@ -314,6 +333,7 @@ impl ACSClientBuilder {
                 api_version: self.api_version,
                 http_client,
                 max_retries: self.max_retries,
+                poll_interval: self.poll_interval,
             });
         }
 
@@ -334,6 +354,7 @@ impl ACSClientBuilder {
             api_version: self.api_version,
             http_client,
             max_retries: self.max_retries,
+            poll_interval: self.poll_interval,
         })
     }
 }
@@ -369,6 +390,42 @@ impl ACSClient {
             email,
             &self.api_version,
             self.max_retries,
+            None,
+        )
+        .await
+    }
+
+    /// Submit an email with a caller-supplied idempotency key.
+    ///
+    /// Behaves like [`send_email`] but sets `repeatability-request-id` and
+    /// `repeatability-first-sent` headers on every attempt (including retries).
+    /// ACS deduplicates requests that share the same key within a short window,
+    /// making application-level retries safe against double-sends.
+    ///
+    /// `idempotency_key` must be a valid UUID string (e.g. `Uuid::new_v4().to_string()`).
+    /// Do not reuse the same key for a different email payload.
+    ///
+    /// # Errors
+    ///
+    /// Same variants as [`send_email`].
+    ///
+    /// [`send_email`]: ACSClient::send_email
+    #[instrument(skip(self, email), fields(host = %self.host, api_version = %self.api_version.as_str()))]
+    pub async fn send_email_idempotent(
+        &self,
+        email: &SentEmail,
+        idempotency_key: &str,
+    ) -> EmailResult<String> {
+        let request_id = Uuid::new_v4().to_string();
+        acs_send_email(
+            &self.http_client,
+            &self.base_url,
+            &self.auth_method,
+            &request_id,
+            email,
+            &self.api_version,
+            self.max_retries,
+            Some(idempotency_key),
         )
         .await
     }
@@ -421,6 +478,7 @@ impl ACSClient {
             email,
             &self.api_version,
             self.max_retries,
+            None,
         )
         .await?;
 
@@ -428,7 +486,7 @@ impl ACSClient {
         let (tx, rx) = oneshot::channel();
         tokio::spawn(async move {
             loop {
-                sleep(Duration::from_secs(5)).await;
+                sleep(self.poll_interval).await;
                 let resp_status = self.get_email_status(&message_id).await;
                 if let Ok(status) = resp_status {
                     call_back(message_id.clone(), &status, None);
@@ -489,13 +547,14 @@ impl ACSClient {
             email,
             &self.api_version,
             self.max_retries,
+            None,
         )
         .await?;
 
         let returned_id = message_id.clone();
         let poll_stream = stream! {
             loop {
-                sleep(Duration::from_secs(5)).await;
+                sleep(self.poll_interval).await;
                 match self.get_email_status(&message_id).await {
                     Ok(status) => {
                         let terminal = is_terminal_status(&status);
@@ -530,6 +589,40 @@ impl ACSClient {
     #[instrument(skip(self, emails), fields(host = %self.host, count = emails.len()))]
     pub async fn send_emails_batch(&self, emails: &[SentEmail]) -> Vec<EmailResult<String>> {
         futures::future::join_all(emails.iter().map(|e| self.send_email(e))).await
+    }
+
+    /// Send an email and block until a terminal delivery status is observed or `timeout` elapses.
+    ///
+    /// Sends the email via [`send_email`], then polls [`get_email_status`] every
+    /// [`poll_interval`] until `Succeeded`, `Failed`, `Canceled`, or `Unknown` is
+    /// returned, or until `timeout` has elapsed.
+    ///
+    /// # Errors
+    ///
+    /// - [`ACSError::Timeout`] — no terminal status observed within `timeout`.
+    /// - All errors from [`send_email`] and [`get_email_status`].
+    ///
+    /// [`send_email`]: ACSClient::send_email
+    /// [`get_email_status`]: ACSClient::get_email_status
+    /// [`poll_interval`]: ACSClientBuilder::poll_interval
+    #[instrument(skip(self, email), fields(host = %self.host, api_version = %self.api_version.as_str()))]
+    pub async fn send_email_and_wait(
+        &self,
+        email: &SentEmail,
+        timeout: Duration,
+    ) -> EmailResult<EmailSendStatusType> {
+        let operation_id = self.send_email(email).await?;
+        tokio::time::timeout(timeout, async {
+            loop {
+                sleep(self.poll_interval).await;
+                let status = self.get_email_status(&operation_id).await?;
+                if is_terminal_status(&status) {
+                    return Ok(status);
+                }
+            }
+        })
+        .await
+        .map_err(|_| ACSError::Timeout)?
     }
 
     /// Stream delivery status updates with cooperative cancellation.
@@ -574,6 +667,7 @@ impl ACSClient {
             email,
             &self.api_version,
             self.max_retries,
+            None,
         )
         .await?;
 
@@ -582,7 +676,7 @@ impl ACSClient {
             loop {
                 tokio::select! {
                     _ = token.cancelled() => { break; }
-                    _ = sleep(Duration::from_secs(5)) => {
+                    _ = sleep(self.poll_interval) => {
                         match self.get_email_status(&message_id).await {
                             Ok(status) => {
                                 let terminal = is_terminal_status(&status);
@@ -634,6 +728,7 @@ impl ACSClient {
             email,
             &self.api_version,
             self.max_retries,
+            None,
         )
         .await?;
 
@@ -646,7 +741,7 @@ impl ACSClient {
                         let _ = tx.send(());
                         break;
                     }
-                    _ = sleep(Duration::from_secs(5)) => {
+                    _ = sleep(self.poll_interval) => {
                         let resp_status = self.get_email_status(&message_id).await;
                         if let Ok(status) = resp_status {
                             call_back(message_id.clone(), &status, None);
@@ -710,7 +805,7 @@ impl ACSClient {
     }
 }
 
-#[instrument(skip(http_client, body, acs_auth_method), fields(method = %method, url = %url))]
+#[instrument(skip(http_client, body, acs_auth_method, extra_headers), fields(method = %method, url = %url))]
 async fn send_request<T>(
     http_client: &Client,
     method: reqwest::Method,
@@ -718,13 +813,14 @@ async fn send_request<T>(
     request_id: &str,
     body: Option<&T>,
     acs_auth_method: &ACSAuthMethod,
+    extra_headers: Option<&reqwest::header::HeaderMap>,
 ) -> EmailResult<reqwest::Response>
 where
     T: serde::Serialize,
 {
     let url_endpoint = parse_url(url)?;
     let json_body = serialize_body(body)?;
-    let headers = create_headers(
+    let mut headers = create_headers(
         http_client,
         &url_endpoint,
         method.as_str(),
@@ -733,6 +829,11 @@ where
         acs_auth_method,
     )
     .await?;
+    if let Some(extra) = extra_headers {
+        for (key, value) in extra.iter() {
+            headers.insert(key.clone(), value.clone());
+        }
+    }
     let request_builder = http_client.request(method, url).headers(headers);
     let request_builder = if let Some(body) = body {
         request_builder.json(body)
@@ -926,6 +1027,7 @@ async fn acs_get_email_status(
         request_id,
         None,
         acs_auth_method,
+        None,
     )
     .await?;
     if response.status() == StatusCode::OK {
@@ -940,6 +1042,24 @@ async fn acs_get_email_status(
     }
 }
 
+fn build_repeatability_headers(
+    idempotency_key: Option<&str>,
+) -> Option<reqwest::header::HeaderMap> {
+    let key = idempotency_key?;
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::HeaderName::from_static("repeatability-request-id"),
+        key.parse().unwrap(),
+    );
+    headers.insert(
+        reqwest::header::HeaderName::from_static("repeatability-first-sent"),
+        httpdate::fmt_http_date(std::time::SystemTime::now())
+            .parse()
+            .unwrap(),
+    );
+    Some(headers)
+}
+
 /// Send an email using the ACS client.
 ///
 /// # Arguments
@@ -952,7 +1072,8 @@ async fn acs_get_email_status(
 /// # Returns
 ///
 /// * `EmailResult<String>` - The result of the email send operation, containing the message ID if successful.
-#[instrument(skip(http_client, acs_auth_method, email), fields(base_url = %base_url, max_retries = %max_retries))]
+#[allow(clippy::too_many_arguments)]
+#[instrument(skip(http_client, acs_auth_method, email, idempotency_key), fields(base_url = %base_url, max_retries = %max_retries))]
 async fn acs_send_email(
     http_client: &Client,
     base_url: &str,
@@ -961,6 +1082,7 @@ async fn acs_send_email(
     email: &SentEmail,
     api_version: &ACSApiVersion,
     max_retries: u32,
+    idempotency_key: Option<&str>,
 ) -> EmailResult<String> {
     let url = format!(
         "{}/emails:send?api-version={}",
@@ -968,6 +1090,7 @@ async fn acs_send_email(
         api_version.as_str()
     );
     debug!("end point URL: {}", url);
+    let extra_headers = build_repeatability_headers(idempotency_key);
     let response = send_request(
         http_client,
         reqwest::Method::POST,
@@ -975,6 +1098,7 @@ async fn acs_send_email(
         request_id,
         Some(email),
         acs_auth_method,
+        extra_headers.as_ref(),
     )
     .await?;
     debug!("{:#?}", response);
@@ -987,6 +1111,7 @@ async fn acs_send_email(
         Some(email),
         acs_auth_method,
         max_retries,
+        extra_headers.as_ref(),
     )
     .await
 }
@@ -1015,6 +1140,7 @@ async fn handle_response_and_retry_if_needed<T>(
     body: Option<&T>,
     acs_auth_method: &ACSAuthMethod,
     max_retries: u32,
+    extra_headers: Option<&reqwest::header::HeaderMap>,
 ) -> EmailResult<String>
 where
     T: serde::Serialize,
@@ -1067,6 +1193,7 @@ where
                     request_id,
                     body,
                     acs_auth_method,
+                    extra_headers,
                 )
                 .await?;
                 response = new_response;
@@ -1329,6 +1456,13 @@ mod tests {
     }
 
     #[test]
+    fn acs_error_display_timeout() {
+        let e = ACSError::Timeout;
+        let s = e.to_string();
+        assert!(s.contains("timed out"));
+    }
+
+    #[test]
     fn acs_error_from_error_response() {
         let resp = ErrorResponse {
             error: Some(crate::domain::entities::models::ErrorDetail {
@@ -1577,6 +1711,63 @@ mod tests {
     #[test]
     fn is_not_terminal_running() {
         assert!(!is_terminal_status(&EmailSendStatusType::Running));
+    }
+
+    // ── poll_interval ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn builder_default_poll_interval_is_5s() {
+        let conn = "endpoint=https://example.com;accesskey=c2VjcmV0";
+        let client = ACSClientBuilder::new()
+            .connection_string(conn)
+            .build()
+            .unwrap();
+        assert_eq!(client.poll_interval, DEFAULT_POLL_INTERVAL);
+    }
+
+    #[test]
+    fn builder_respects_custom_poll_interval() {
+        let conn = "endpoint=https://example.com;accesskey=c2VjcmV0";
+        let client = ACSClientBuilder::new()
+            .connection_string(conn)
+            .poll_interval(Duration::from_millis(500))
+            .build()
+            .unwrap();
+        assert_eq!(client.poll_interval, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn builder_poll_interval_propagates_to_service_principal() {
+        let client = ACSClientBuilder::new()
+            .host("example.com")
+            .service_principal("t", "c", "s")
+            .poll_interval(Duration::from_secs(10))
+            .build()
+            .unwrap();
+        assert_eq!(client.poll_interval, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn builder_poll_interval_propagates_via_connection_string() {
+        let conn = "endpoint=https://example.com;accesskey=c2VjcmV0";
+        let client = ACSClientBuilder::new()
+            .connection_string(conn)
+            .poll_interval(Duration::from_millis(250))
+            .build()
+            .unwrap();
+        assert_eq!(client.poll_interval, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn client_clone_preserves_poll_interval() {
+        let conn = "endpoint=https://example.com;accesskey=c2VjcmV0";
+        let client = ACSClientBuilder::new()
+            .connection_string(conn)
+            .poll_interval(Duration::from_secs(7))
+            .build()
+            .unwrap();
+        let cloned = client.clone();
+        assert_eq!(cloned.poll_interval, Duration::from_secs(7));
     }
 }
 
@@ -2577,5 +2768,275 @@ mod integration_tests {
 
         let result = client.send_email(&minimal_email()).await;
         assert_eq!(result.unwrap(), "after-retry");
+    }
+
+    // ── send_email_and_wait ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_email_and_wait_returns_terminal_status() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+        let op_id = "op-wait-1";
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(json!({ "id": op_id })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "status": "Succeeded" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .poll_interval(Duration::from_millis(10))
+            .build()
+            .unwrap();
+
+        let result = client
+            .send_email_and_wait(&email, Duration::from_secs(5))
+            .await;
+        assert!(matches!(result, Ok(EmailSendStatusType::Succeeded)));
+    }
+
+    #[tokio::test]
+    async fn send_email_and_wait_times_out() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+        let op_id = "op-wait-timeout";
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(json!({ "id": op_id })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "Running" })))
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .poll_interval(Duration::from_secs(60)) // longer than timeout
+            .build()
+            .unwrap();
+
+        let result = client
+            .send_email_and_wait(&email, Duration::from_millis(50))
+            .await;
+        assert!(matches!(result, Err(ACSError::Timeout)));
+    }
+
+    // ── send_email_idempotent ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_email_idempotent_sends_repeatability_headers() {
+        use wiremock::matchers::header_exists;
+
+        let server = MockServer::start().await;
+        let email = minimal_email();
+        let key = uuid::Uuid::new_v4().to_string();
+
+        Mock::given(method("POST"))
+            .and(header_exists("repeatability-request-id"))
+            .and(header_exists("repeatability-first-sent"))
+            .respond_with(
+                ResponseTemplate::new(202).set_body_json(json!({ "id": "op-idempotent-1" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .build()
+            .unwrap();
+
+        let result = client.send_email_idempotent(&email, &key).await;
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn send_email_idempotent_returns_operation_id() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+        let key = uuid::Uuid::new_v4().to_string();
+
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(202).set_body_json(json!({ "id": "idempotent-op-42" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .build()
+            .unwrap();
+
+        let result = client.send_email_idempotent(&email, &key).await;
+        assert_eq!(result.unwrap(), "idempotent-op-42");
+    }
+
+    #[tokio::test]
+    async fn send_email_idempotent_retries_on_429_preserves_key() {
+        use wiremock::matchers::header_exists;
+
+        let server = MockServer::start().await;
+        let email = minimal_email();
+        let key = uuid::Uuid::new_v4().to_string();
+
+        // First request: 429; second attempt: 202
+        Mock::given(method("POST"))
+            .and(header_exists("repeatability-request-id"))
+            .respond_with(ResponseTemplate::new(429))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(header_exists("repeatability-request-id"))
+            .respond_with(
+                ResponseTemplate::new(202).set_body_json(json!({ "id": "idempotent-retry-op" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .max_retries(1)
+            .build()
+            .unwrap();
+
+        let result = client.send_email_idempotent(&email, &key).await;
+        assert_eq!(result.unwrap(), "idempotent-retry-op");
+    }
+
+    #[tokio::test]
+    async fn send_email_and_wait_returns_failed_status() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(json!({ "id": "op-fail" })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "status": "Failed" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .poll_interval(Duration::from_millis(10))
+            .build()
+            .unwrap();
+
+        let result = client
+            .send_email_and_wait(&email, Duration::from_secs(5))
+            .await;
+        assert!(matches!(result, Ok(EmailSendStatusType::Failed)));
+    }
+
+    #[tokio::test]
+    async fn send_email_and_wait_send_fails_returns_send_error() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(
+                json!({ "error": { "code": "InternalError", "message": "boom" } }),
+            ))
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .max_retries(0)
+            .build()
+            .unwrap();
+
+        let result = client
+            .send_email_and_wait(&email, Duration::from_secs(5))
+            .await;
+        // Must be a send-level Api error, not Timeout
+        assert!(matches!(result, Err(ACSError::Api { .. })));
+    }
+
+    #[tokio::test]
+    async fn send_email_and_wait_poll_error_propagates() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(json!({ "id": "op-poll-err" })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(
+                json!({ "error": { "code": "OperationNotFound", "message": "not found" } }),
+            ))
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .poll_interval(Duration::from_millis(10))
+            .build()
+            .unwrap();
+
+        let result = client
+            .send_email_and_wait(&email, Duration::from_secs(5))
+            .await;
+        // Must be a poll-level Api error, not Timeout
+        assert!(matches!(result, Err(ACSError::Api { .. })));
+    }
+
+    #[tokio::test]
+    async fn send_email_and_wait_running_then_succeeded() {
+        let server = MockServer::start().await;
+        let email = minimal_email();
+
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(202).set_body_json(json!({ "id": "op-running-ok" })),
+            )
+            .mount(&server)
+            .await;
+        // First GET: Running; subsequent GETs: Succeeded
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "status": "Running" })),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "status": "Succeeded" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ACSClientBuilder::new()
+            .connection_string(FAKE_CONN)
+            .base_url_override(&server.uri())
+            .poll_interval(Duration::from_millis(10))
+            .build()
+            .unwrap();
+
+        let result = client
+            .send_email_and_wait(&email, Duration::from_secs(5))
+            .await;
+        assert!(matches!(result, Ok(EmailSendStatusType::Succeeded)));
     }
 }

--- a/src/adapters/gateways/acs_email.rs
+++ b/src/adapters/gateways/acs_email.rs
@@ -2926,9 +2926,7 @@ mod integration_tests {
             .mount(&server)
             .await;
         Mock::given(method("GET"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({ "status": "Failed" })),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "Failed" })))
             .mount(&server)
             .await;
 
@@ -2951,9 +2949,11 @@ mod integration_tests {
         let email = minimal_email();
 
         Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(500).set_body_json(
-                json!({ "error": { "code": "InternalError", "message": "boom" } }),
-            ))
+            .respond_with(
+                ResponseTemplate::new(500).set_body_json(
+                    json!({ "error": { "code": "InternalError", "message": "boom" } }),
+                ),
+            )
             .mount(&server)
             .await;
 
@@ -3014,9 +3014,7 @@ mod integration_tests {
             .await;
         // First GET: Running; subsequent GETs: Succeeded
         Mock::given(method("GET"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({ "status": "Running" })),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "Running" })))
             .up_to_n_times(1)
             .mount(&server)
             .await;

--- a/src/adapters/gateways/acs_shared_key.rs
+++ b/src/adapters/gateways/acs_shared_key.rs
@@ -93,7 +93,6 @@ pub fn parse_endpoint(endpoint: &str) -> Result<EndPointParams, String> {
             debug!("Host name: {}", end_point_params.host_name);
         } else if let Some(key) = param.strip_prefix("accesskey=") {
             end_point_params.access_key = key.to_string();
-            debug!("Access key: {}", end_point_params.access_key);
         } else {
             return Err("Invalid parameter in connection string".to_string());
         }

--- a/src/domain/entities/models.rs
+++ b/src/domain/entities/models.rs
@@ -68,6 +68,12 @@ pub enum ACSError {
     /// Rate limit hit and all retries were exhausted.
     #[error("rate limit exceeded after {retries} retries")]
     RateLimitExceeded { retries: u32 },
+
+    /// [`send_email_and_wait`] did not observe a terminal status within the given timeout.
+    ///
+    /// [`send_email_and_wait`]: crate::adapters::gateways::acs_email::ACSClient::send_email_and_wait
+    #[error("timed out waiting for terminal delivery status")]
+    Timeout,
 }
 
 impl From<ErrorResponse> for ACSError {

--- a/src/domain/entities/models.rs
+++ b/src/domain/entities/models.rs
@@ -74,6 +74,15 @@ pub enum ACSError {
     /// [`send_email_and_wait`]: crate::adapters::gateways::acs_email::ACSClient::send_email_and_wait
     #[error("timed out waiting for terminal delivery status")]
     Timeout,
+
+    /// Polling was stopped early because the [`CancellationToken`] passed to
+    /// [`send_email_and_wait_cancellable`] was cancelled before a terminal
+    /// delivery status was observed.
+    ///
+    /// [`CancellationToken`]: tokio_util::sync::CancellationToken
+    /// [`send_email_and_wait_cancellable`]: crate::adapters::gateways::acs_email::ACSClient::send_email_and_wait_cancellable
+    #[error("polling cancelled by caller before terminal status was observed")]
+    Canceled,
 }
 
 impl From<ErrorResponse> for ACSError {


### PR DESCRIPTION
This pull request releases version 0.4.0 of the Azure ECS Rust SDK, introducing new send-and-wait APIs, enhanced configurability, improved documentation, and security fixes. The highlights include support for blocking and cancellable email send methods, a configurable poll interval, idempotent send support, new error variants, and removal of sensitive data from logs. The documentation and examples have been updated accordingly, and test coverage has been expanded.

**Major new features and API changes:**

* Added `send_email_and_wait` and `send_email_and_wait_cancellable` methods to `ACSClient`, allowing callers to send an email and await a terminal status, with optional cancellation support. These methods return new error variants (`ACSError::Timeout`, `ACSError::Canceled`). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R37) [[2]](diffhunk://#diff-9b3e5bc338ee6612d81bb246bbd83450af06ff76737e9879261baeb664cc05feR1-R137) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R241-R292) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L108-R142)
* Introduced `.poll_interval(Duration)` on `ACSClientBuilder` to control the delay between status polls for all relevant APIs. The poll interval is now a configurable field of `ACSClient`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R37) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L45-R46) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L108-R142)
* Added `send_email_idempotent` to `ACSClient`, ensuring safe retries with idempotency headers. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R37) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L108-R142)
* Expanded the `ACSError` enum with `Timeout` and `Canceled` variants, and documented all variants. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R37) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L45-R46) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L108-R142)
* Version bump to 0.4.0 in `Cargo.toml`.

**Security and logging improvements:**

* Removed logging of sensitive secrets: the access key in `acs_shared_key::parse_endpoint` and the OAuth client secret in `examples/mail.rs` are no longer emitted at any log level. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R37) [[2]](diffhunk://#diff-5dc8492bd6355f03b851cba43c8f878f82e2506ebc4c87bbb6968a157848ca83L96) [[3]](diffhunk://#diff-058ce011fc08659086a9b0a580d7bab331b3199ea3bc62f89758fce17308c8ebL118)

**Documentation and examples:**

* README now includes a comprehensive "Choosing a Send Method" section with a decision table and flowchart, as well as code examples for the new send-and-wait APIs. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R80) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R241-R292)
* Added a new example, `examples/mail_wait.rs`, demonstrating the new send-and-wait and cancellable APIs. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R37) [[2]](diffhunk://#diff-9b3e5bc338ee6612d81bb246bbd83450af06ff76737e9879261baeb664cc05feR1-R137) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R391-R398)
* All public builder methods now use Rust doc comments for improved docs.rs visibility.

**Testing and internal changes:**

* Increased test coverage from 136 to 157, with new unit and integration tests for poll interval propagation, all send-and-wait/cancellable/idempotent paths, error handling, and idempotency header behavior. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R37) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L15-R23) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R66-R79)
* Updated `CLAUDE.md` to document the expanded API, error variants, and test suite. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R37) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L45-R46) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R66-R79) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L108-R142)

This release is backward compatible for existing callers, with all new features opt-in and default behaviors unchanged.